### PR TITLE
🎨 Palette: Add loading indicator for scene transitions

### DIFF
--- a/js/engine/SceneManager.js
+++ b/js/engine/SceneManager.js
@@ -1,5 +1,6 @@
 import { Scene } from './Scene.js';
 import { loadSceneFromConfig } from './scene-loader.js';
+import { showLoadingIndicator, hideLoadingIndicator } from './ui/loading-indicator.js';
 
 class SceneManager {
     constructor() {
@@ -35,6 +36,7 @@ class SceneManager {
             return;
         }
         this.isLoading = true;
+        showLoadingIndicator();
 
         console.log(`Loading scene: ${name}`);
 
@@ -72,6 +74,7 @@ class SceneManager {
             throw error;
         } finally {
             this.isLoading = false;
+            hideLoadingIndicator();
         }
     }
 

--- a/js/engine/ui/loading-indicator.js
+++ b/js/engine/ui/loading-indicator.js
@@ -1,0 +1,49 @@
+const LOADING_INDICATOR_ID = 'loading-indicator';
+
+/**
+ * Creates and shows a loading indicator overlay.
+ */
+export function showLoadingIndicator() {
+    // If the indicator already exists, do nothing.
+    if (document.getElementById(LOADING_INDICATOR_ID)) {
+        return;
+    }
+
+    // Create the overlay element
+    const overlay = document.createElement('div');
+    overlay.id = LOADING_INDICATOR_ID;
+    overlay.style.position = 'fixed';
+    overlay.style.top = '0';
+    overlay.style.left = '0';
+    overlay.style.width = '100%';
+    overlay.style.height = '100%';
+    overlay.style.backgroundColor = 'rgba(0, 0, 0, 0.8)';
+    overlay.style.display = 'flex';
+    overlay.style.justifyContent = 'center';
+    overlay.style.alignItems = 'center';
+    overlay.style.zIndex = '2000'; // Higher than error display
+    overlay.style.color = '#fff';
+    overlay.style.fontFamily = 'sans-serif';
+    overlay.style.fontSize = '24px';
+
+    // Accessibility attributes
+    overlay.setAttribute('role', 'status');
+    overlay.setAttribute('aria-live', 'polite');
+    overlay.setAttribute('aria-label', 'Loading scene');
+
+    // Add content to the overlay
+    overlay.textContent = 'Loading...';
+
+    // Append to the body
+    document.body.appendChild(overlay);
+}
+
+/**
+ * Hides the loading indicator overlay.
+ */
+export function hideLoadingIndicator() {
+    const indicator = document.getElementById(LOADING_INDICATOR_ID);
+    if (indicator) {
+        indicator.remove();
+    }
+}


### PR DESCRIPTION
This change introduces a user-facing loading indicator to improve the experience during scene transitions. It adds a new UI component for the overlay and integrates it into the `SceneManager` to show and hide it at the appropriate times. The change is fully accessible and has been visually verified.

---
*PR created automatically by Jules for task [18282754692398806527](https://jules.google.com/task/18282754692398806527) started by @Coolguy1211*