### PR TITLE
🎨 Palette: Add Loading Screen for Scene Transitions

### DIFF
--- a/css/ui.css
+++ b/css/ui.css
@@ -1,0 +1,19 @@
+
+#loading-screen-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.7);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    font-family: sans-serif;
+}
+
+#loading-screen-overlay p {
+    color: #fff;
+    font-size: 24px;
+}

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>My first three.js app</title>
+		<link rel="stylesheet" href="css/ui.css">
 		<style>
 			body { margin: 0; }
 		</style>

--- a/js/engine/SceneManager.js
+++ b/js/engine/SceneManager.js
@@ -1,5 +1,6 @@
 import { Scene } from './Scene.js';
 import { loadSceneFromConfig } from './scene-loader.js';
+import { showLoadingScreen, hideLoadingScreen } from './ui/loading-screen.js';
 
 class SceneManager {
     constructor() {
@@ -35,6 +36,7 @@ class SceneManager {
             return;
         }
         this.isLoading = true;
+        showLoadingScreen();
 
         console.log(`Loading scene: ${name}`);
 
@@ -72,6 +74,7 @@ class SceneManager {
             throw error;
         } finally {
             this.isLoading = false;
+            hideLoadingScreen();
         }
     }
 

--- a/js/engine/ui/loading-screen.js
+++ b/js/engine/ui/loading-screen.js
@@ -1,0 +1,38 @@
+const LOADING_SCREEN_ID = 'loading-screen-overlay';
+
+/**
+ * Displays a loading screen overlay by creating the necessary DOM elements
+ * and assigning them an ID that is styled by an external CSS file.
+ */
+export function showLoadingScreen() {
+    // If a loading screen is already present, do nothing.
+    if (document.getElementById(LOADING_SCREEN_ID)) {
+        return;
+    }
+
+    // Create the overlay element and assign it the ID for styling.
+    const overlay = document.createElement('div');
+    overlay.id = LOADING_SCREEN_ID;
+    overlay.setAttribute('role', 'status');
+    overlay.setAttribute('aria-live', 'assertive');
+
+    // Create the message element
+    const messageElement = document.createElement('p');
+    messageElement.textContent = 'Loading...';
+
+    // Assemble the elements
+    overlay.appendChild(messageElement);
+
+    // Add to the body
+    document.body.appendChild(overlay);
+}
+
+/**
+ * Hides the loading screen overlay.
+ */
+export function hideLoadingScreen() {
+    const overlay = document.getElementById(LOADING_SCREEN_ID);
+    if (overlay) {
+        overlay.remove();
+    }
+}


### PR DESCRIPTION
### 💡 What
This change adds a simple, clean loading screen that appears whenever a new 3D scene is being loaded in the background. It replaces the previous blank screen, providing clear visual feedback to the user.

### 🎯 Why
Previously, the application would show a blank white screen during scene transitions. This could make the application feel frozen or unresponsive, leading to a poor user experience. The new loading screen reassures the user that the application is working and content is on the way.

### 📸 Before/After

**Before:** A blank screen during loading.
**After:** A clear "Loading..." message.
![Loading Screen](https://storage.googleapis.com/agent-tools-public/2126ac5e-049d-488f-a96e-a2f07d24220b.png)


### ♿ Accessibility
The loading screen has been built with accessibility in mind:
- It uses `role="status"` and `aria-live="assertive"` attributes to ensure that screen reader users are notified that the application is in a loading state.

---
*PR created automatically by Jules for task [308407064187189082](https://jules.google.com/task/308407064187189082) started by @Coolguy1211*