### PR TITLE
🎨 Palette: Add Scene Loading Indicator

### DIFF
--- a/js/engine/SceneManager.js
+++ b/js/engine/SceneManager.js
@@ -1,5 +1,6 @@
 import { Scene } from './Scene.js';
 import { loadSceneFromConfig } from './scene-loader.js';
+import { showLoadingIndicator, hideLoadingIndicator } from './ui/loading-indicator.js';
 
 class SceneManager {
     constructor() {
@@ -35,6 +36,7 @@ class SceneManager {
             return;
         }
         this.isLoading = true;
+        showLoadingIndicator();
 
         console.log(`Loading scene: ${name}`);
 
@@ -72,6 +74,7 @@ class SceneManager {
             throw error;
         } finally {
             this.isLoading = false;
+            hideLoadingIndicator();
         }
     }
 

--- a/js/engine/ui/loading-indicator.js
+++ b/js/engine/ui/loading-indicator.js
@@ -1,0 +1,68 @@
+const LOADING_INDICATOR_ID = 'loading-indicator-overlay';
+const STYLE_ID = 'loading-indicator-style';
+
+function createSpinnerStyles() {
+    const styleElement = document.createElement('style');
+    styleElement.id = STYLE_ID;
+    styleElement.textContent = `
+        .spinner {
+            width: 50px;
+            height: 50px;
+            border: 5px solid rgba(255, 255, 255, 0.3);
+            border-radius: 50%;
+            border-top-color: #fff;
+            animation: spin 1s ease-in-out infinite;
+        }
+
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+    `;
+    return styleElement;
+}
+
+export function showLoadingIndicator() {
+    if (document.getElementById(LOADING_INDICATOR_ID)) {
+        return;
+    }
+
+    // Add styles to the head
+    document.head.appendChild(createSpinnerStyles());
+
+    // Create the overlay element
+    const overlay = document.createElement('div');
+    overlay.id = LOADING_INDICATOR_ID;
+    overlay.style.position = 'fixed';
+    overlay.style.top = '0';
+    overlay.style.left = '0';
+    overlay.style.width = '100%';
+    overlay.style.height = '100%';
+    overlay.style.backgroundColor = 'rgba(0, 0, 0, 0.5)';
+    overlay.style.display = 'flex';
+    overlay.style.justifyContent = 'center';
+    overlay.style.alignItems = 'center';
+    overlay.style.zIndex = '1001';
+    overlay.setAttribute('role', 'status');
+    overlay.setAttribute('aria-live', 'polite');
+    overlay.setAttribute('aria-label', 'Loading scene');
+
+    // Create the spinner
+    const spinner = document.createElement('div');
+    spinner.className = 'spinner';
+
+    // Assemble and append to body
+    overlay.appendChild(spinner);
+    document.body.appendChild(overlay);
+}
+
+export function hideLoadingIndicator() {
+    const overlay = document.getElementById(LOADING_INDICATOR_ID);
+    if (overlay) {
+        overlay.remove();
+    }
+
+    const styleElement = document.getElementById(STYLE_ID);
+    if (styleElement) {
+        styleElement.remove();
+    }
+}


### PR DESCRIPTION
### 💡 What:
This change introduces a visual loading indicator (a spinner) that appears whenever a new scene is being loaded.

### 🎯 Why:
Previously, the application would show a blank white screen during scene transitions. This could make the application feel frozen or broken, especially on slower connections or with large scenes. The new loading indicator provides immediate visual feedback, reassuring the user that the application is working.

### 📸 Before/After:
*   **Before:** A blank white screen with no feedback.
*   **After:** A semi-transparent overlay with a spinner, clearly indicating a loading state. (Note: The final scene rendering is currently blocked by a pre-existing bug, but the loading indicator itself is fully functional).

### ♿ Accessibility:
The loading indicator includes `role="status"`, `aria-live="polite"`, and an `aria-label` to ensure that screen reader users are notified when content is loading.

---
*PR created automatically by Jules for task [8529137057320281810](https://jules.google.com/task/8529137057320281810) started by @Coolguy1211*